### PR TITLE
fix: bug on strip tag

### DIFF
--- a/insertfield_builder.go
+++ b/insertfield_builder.go
@@ -23,13 +23,13 @@ func createInsertField(typeOf reflect.Type, valueOf reflect.Value, fieldSelector
 		value := valueOf.Field(i)
 		switch fieldSelectorType {
 		case ExcludeField:
-			if fieldMap[name] != name || len(fieldMap) == 0 {
+			if (fieldMap[name] != name || len(fieldMap) == 0) && name != "-" {
 				fieldName = append(fieldName, name)
 				fieldPlaceholder = append(fieldPlaceholder, "?")
 				fieldValue = append(fieldValue, value.Interface())
 			}
 		default:
-			if fieldMap[name] == name || len(fieldMap) == 0 {
+			if (fieldMap[name] == name || len(fieldMap) == 0) && name != "-" {
 				fieldName = append(fieldName, name)
 				fieldPlaceholder = append(fieldPlaceholder, "?")
 				fieldValue = append(fieldValue, value.Interface())
@@ -68,6 +68,9 @@ func BuildInsertField(entities interface{}, fieldSelectorType TypeFieldSelect, f
 			}
 
 			fname, fplaceholder, fvalue := createInsertField(typeOf, valueOf, fieldSelectorType, fieldMap)
+			if fname == nil || fplaceholder == nil || fvalue == nil {
+				continue
+			}
 
 			fieldName = fname
 			fieldPlaceholders = append(fieldPlaceholders, fmt.Sprintf("(%s)", strings.Join(fplaceholder, ",")))
@@ -83,6 +86,10 @@ func BuildInsertField(entities interface{}, fieldSelectorType TypeFieldSelect, f
 			return InsertField{}, errors.New("not a struct")
 		}
 		fname, fplaceholder, fvalue := createInsertField(typeOfEntities, valuesOfEntities, fieldSelectorType, fieldMap)
+		if fname == nil || fplaceholder == nil || fvalue == nil {
+			return InsertField{}, nil
+		}
+
 		fieldName = fname
 		fieldPlaceholders = append(fieldPlaceholders, fmt.Sprintf("(%s)", strings.Join(fplaceholder, ",")))
 		fieldValues = append(fieldValues, fvalue...)

--- a/insertfield_builder_test.go
+++ b/insertfield_builder_test.go
@@ -131,6 +131,41 @@ func TestInsertFieldBuilder(t *testing.T) {
 				return sqlsqbdr.BuildInsertField(humans[0], sqlsqbdr.IncludeField)
 			},
 		},
+		{
+			name: "test4 - tag strip",
+			expected: func() sqlsqbdr.InsertField {
+				return sqlsqbdr.InsertField{
+					Name:        []string{"name", "age", "gender"},
+					Placeholder: []string{"(?,?,?)"},
+					Values:      []any{"test", 1, "M"},
+				}
+			},
+			actual: func() (sqlsqbdr.InsertField, error) {
+				type Human struct {
+					Name   string `json:"name" db:"name"`
+					Age    int    `json:"age" db:"age"`
+					Gender string `json:"gender" db:"gender"`
+					Non    string `json:"-" db:"-"`
+				}
+
+				type Humans []*Human
+				humans := Humans{
+					{
+						Name:   "test",
+						Age:    1,
+						Gender: "M",
+						Non:    "ABC",
+					},
+					{
+						Name:   "test2",
+						Age:    2,
+						Gender: "M",
+						Non:    "ABC",
+					},
+				}
+				return sqlsqbdr.BuildInsertField(humans[0], sqlsqbdr.IncludeField)
+			},
+		},
 	}
 
 	for _, tc := range testCase {

--- a/updatefield_builder_test.go
+++ b/updatefield_builder_test.go
@@ -155,6 +155,29 @@ func TestBuildUpdatedField(t *testing.T) {
 				return sqlsqbdr.BuildUpdatedField(a, sqlsqbdr.IncludeField, "name", "age")
 			},
 		},
+		{
+			name: "test8 - with strip",
+			exp: func() sqlsqbdr.UpdatedField {
+				return sqlsqbdr.UpdatedField{
+					Name:  []string{"name = ?", "age = ?"},
+					Value: []any{"test", null.Int{sql.NullInt64{Valid: true, Int64: 1}}},
+				}
+			},
+			act: func() (sqlsqbdr.UpdatedField, error) {
+				human := struct {
+					Name   string   `json:"name" db:"name"`
+					Age    null.Int `json:"age" db:"age"`
+					Gender string   `json:"gender" db:"gender"`
+					Non    string   `json:"-" db:"-"`
+				}{
+					Name: "test",
+					Age:  null.IntFrom(1),
+					Non:  "1",
+				}
+
+				return sqlsqbdr.BuildUpdatedField(human, sqlsqbdr.IncludeField, "name", "age")
+			},
+		},
 	}
 
 	for _, tc := range testCase {


### PR DESCRIPTION
Previously, on the entity with a strip tag
```
type Entity struct{
 Test1 string `db:"test1"`
 Test2 string `db:"-"
}
```

it will print the `Test2` into the insertedField feature. this PR is to solve this issue